### PR TITLE
Add Github Actions workflow to build and publish Docker images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -16,6 +16,9 @@ jobs:
     permissions:
       contents: read
       packages: write
+    strategy:
+      matrix:
+        with_influxdb: ["no", "yes"]
     steps:
       -
         name: Checkout
@@ -28,6 +31,8 @@ jobs:
           # list of Docker images to use as base name for tags
           images: |
             ghcr.io/${{ github.repository }}
+          flavor: |
+            suffix=${{ matrix.with_influxdb == 'yes' && '-with-influxdb' || '' }}, onlatest=true
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v2
@@ -47,6 +52,8 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
+          build-args: |
+            with_influxdb=${{ matrix.with_influxdb }}
           platforms: linux/amd64,linux/386,linux/arm64,linux/arm
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -1,0 +1,53 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - "main"
+    tags:
+      - "*"
+  pull_request:
+    branches:
+      - "main"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            ghcr.io/${{ github.repository }}
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Login to Docker Hub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          platforms: linux/amd64,linux/386,linux/arm64,linux/arm
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This builds docker images and publishes them at [ghcr.io/pvtom/rscp2mqtt](https://ghcr.io/pvtom/rscp2mqtt) (see [ghcr.io/martinholters/rscp2mqtt](https://ghcr.io/martinholters/rscp2mqtt) where I've tested this at). Images both with and without InfluxDB support are build. Pushes to the main branch are tagged `main` and `main-with-influxdb`, repectively. Similar for tags, i.e. git tag `v3.2` will be tagged as `v3.2` and `v3.2-with-influxdb`, but they are also tagged with `latest` and `latest-with-influxdb`.

Pull requests also have the images built (to verify they at least build fine), but they are not pushed to the registry. Would it be preferred to also push them for easier testing?

The option of running via docker should probably by mentioned in the README, but before promising anything there, I'd like to see this actually working.

@pvtom, if you have Github actions enabled in the project setting - which I think is the default - you should be able to approve the run here and have images built (but not pushed as said).